### PR TITLE
Fix lintr warnings in nltt_diff_exact_extinct. Progress #52

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Type: Package
 Title: Calculate the NLTT Statistic
 Version: 1.4.4
 Authors@R: c(person("Thijs","Janzen", email = "thijsjanzen@gmail.com",role=c("aut","cre")),
-             person("Richel","Bilderbeek",email="richel@richelbilderbeek.nl", role=c("aut")))
+             person("Richel","Bilderbeek",email="richel@richelbilderbeek.nl", role=c("aut")),
+             person("Pedro", "Neves", email = "p.m.santos.neves@rug.nl", role = "ctb"))
 Description: Provides functions to calculate the normalised Lineage-Through-
     Time (nLTT) statistic, given two phylogenetic trees. The nLTT statistic measures
     the difference between two Lineage-Through-Time curves, where each curve is

--- a/R/nltt_diff_exact_extinct.R
+++ b/R/nltt_diff_exact_extinct.R
@@ -1,3 +1,44 @@
+#' Checks that event times are correct
+#'
+#' @description Checks \code{event_times} and \code{event_times2} are of the
+#'   appropriate class and have expected characteristics for correct calculation
+#'   of NLTT in \code{\link{nltt_diff_exact_extinct}}.
+#' @author Pedro Neves and Richel Bilderbeek and Thijs Janzen
+#'
+#' @param event_times event times of the first phylogeny
+#' @param event_times2 event times of the second phylogeny
+#' @param time_unit the time unit of the branching times
+#' \itemize{
+#'  \item{"ago: "}{the branching times are postive,
+#'    as these are in time units ago}
+#'  \item{"since: "}{the branching times are negative,
+#'    as these are in time units since present}
+#' }
+#'
+#' @return Nothing. Throws error with helpful error message if
+#' \code{event_times} and \code{event_times2} are not correct.
+#' @noRd
+check_input_event_times <- function(event_times, event_times2, time_unit) {
+
+
+  # This function doesn't handle phylo objects
+  if (!is.numeric(event_times) || !is.numeric(event_times2)) {
+    stop("event times should be a numeric vector of event times, not a
+       phylogeny. Use nltt_diff_exact_norm_brts for phylo objects instead.")
+  }
+
+  if (time_unit == "since") {
+    if (!all(event_times <= 0.0) || !all(event_times2 <= 0.0)) {
+      stop("event times must be negative, ",
+           "for example -3 time units since the present")
+    }
+  } else if (!all(event_times >= 0.0) || !all(event_times2 >= 0.0)) {
+    stop("event times must be positive, ",
+         "for example 3 time units ago")
+  }
+
+}
+
 #' Calculates the exact difference between the nLTT
 #' curves of the event times. This includes extinction events.
 #' @description Takes branching times such as (for example) as returned by a
@@ -52,35 +93,19 @@ nltt_diff_exact_extinct <- function(
   distance_method = "abs",
   time_unit = "since",
   normalize = TRUE) {
+
+  check_input_event_times(event_times = event_times,
+                          event_times2 = event_times2,
+                          time_unit = time_unit)
   if (time_unit != "since" && time_unit != "ago") {
     stop("time_unit must be either 'since' or 'ago'")
-  }
-
-  # This function doesn't handle phylo objects
-  if (class(event_times) == "phylo" || class(event_times) == "multiPhylo" ||
-      class(event_times2) == "phylo" || class(event_times2) == "multiPhylo") {
-    stop("event times should be a numeric vector of event times, not a
-       phylogeny. Use nltt_diff_exact_norm_brts for phylo objects instead.")
   }
 
   # Each branching time must have a number of lineages to accompany it
   testit::assert(length(event_times) == length(species_number))
   testit::assert(length(event_times2) == length(species_number2))
 
-  if (time_unit == "since") {
-    if (!all(event_times <= 0.0) || !all(event_times2 <= 0.0)) {
-      stop("event times must be negative, ",
-           "for example -3 time units since the present")
-    }
-  }
-
   if (time_unit == "ago") {
-    if (!all(event_times >= 0.0) || !all(event_times2 >= 0.0)) {
-      stop("event times must be positive, ",
-           "for example 3 time units ago")
-    }
-
-
     # Conformize te b_times for the classic calculation
     event_times <- c(-1.0 * rev(sort(event_times)), 0)
     event_times2 <- c(-1.0 * rev(sort(event_times2)), 0)

--- a/R/nltt_diff_exact_extinct.R
+++ b/R/nltt_diff_exact_extinct.R
@@ -20,7 +20,6 @@
 #' @noRd
 check_input_event_times <- function(event_times, event_times2, time_unit) {
 
-
   # This function doesn't handle phylo objects
   if (!is.numeric(event_times) || !is.numeric(event_times2)) {
     stop("event times should be a numeric vector of event times, not a
@@ -36,20 +35,19 @@ check_input_event_times <- function(event_times, event_times2, time_unit) {
     stop("event times must be positive, ",
          "for example 3 time units ago")
   }
-
 }
 
 #' Calculates the exact difference between the nLTT
 #' curves of the event times. This includes extinction events.
-#' @description Takes branching times such as (for example) as returned by a
-#' \code{\link[DAISIE]{DAISIE_sim}} simulation.
+#' @description Takes branching times such as (for example) as returned by the
+#'   DDD package.
 #' @author Pedro Neves and Richel Bilderbeek and Thijs Janzen
 #'
 #' @param event_times event times of the first phylogeny
 #' @param species_number the number of species at each event time of the first
 #' phylogeny
 #' @param event_times2 event times of the second phylogeny
-#' @param species_number2 the number of species at each evet time of the second
+#' @param species_number2 the number of species at each event time of the second
 #' phylogeny
 #' @param distance_method how the difference between the two nLTTs is summed
 #' \itemize{
@@ -159,10 +157,10 @@ nltt_diff_exact_extinct <- function(
 #' curves of the event times. This includes extinction events.
 #' @author Thijs Janzen and Richel Bilderbeek and Pedro Neves
 #' @param event_times event times of the first phylogeny
-#' @param species_number the number of species at each evet time of the first
+#' @param species_number the number of species at each event time of the first
 #' phylogeny
 #' @param event_times2 event times of the second phylogeny
-#' @param species_number2 the number of species at each evet time of the second
+#' @param species_number2 the number of species at each event time of the second
 #' phylogeny
 #' @param distance_method (string) absolute, or squared distance?
 #'

--- a/man/nltt_diff_exact_calc_extinct.Rd
+++ b/man/nltt_diff_exact_calc_extinct.Rd
@@ -16,12 +16,12 @@ nltt_diff_exact_calc_extinct(
 \arguments{
 \item{event_times}{event times of the first phylogeny}
 
-\item{species_number}{the number of species at each evet time of the first
+\item{species_number}{the number of species at each event time of the first
 phylogeny}
 
 \item{event_times2}{event times of the second phylogeny}
 
-\item{species_number2}{the number of species at each evet time of the second
+\item{species_number2}{the number of species at each event time of the second
 phylogeny}
 
 \item{distance_method}{(string) absolute, or squared distance?}

--- a/man/nltt_diff_exact_extinct.Rd
+++ b/man/nltt_diff_exact_extinct.Rd
@@ -23,7 +23,7 @@ phylogeny}
 
 \item{event_times2}{event times of the second phylogeny}
 
-\item{species_number2}{the number of species at each evet time of the second
+\item{species_number2}{the number of species at each event time of the second
 phylogeny}
 
 \item{distance_method}{how the difference between the two nLTTs is summed
@@ -43,8 +43,8 @@ phylogeny}
 \item{normalize}{should the output be normalized? Default is TRUE.}
 }
 \description{
-Takes branching times such as (for example) as returned by a
-\code{\link[DAISIE]{DAISIE_sim}} simulation.
+Takes branching times such as (for example) as returned by the
+  DDD package.
 }
 \examples{
 

--- a/tests/testthat/test-nltt_diff_exact_extinct.R
+++ b/tests/testthat/test-nltt_diff_exact_extinct.R
@@ -26,8 +26,8 @@ test_that("nltt_diff_exact_extinct: use don't normalize", {
   event_times2 <- sort(runif(154, 0, 10))
 
   # Test of non-increasing lineages
-  lineages1 <- seq_along(event_times)
-  lineages2 <- seq_along(event_times2)
+  lineages1 <- 1:length(event_times)
+  lineages2 <- 1:length(event_times2)
   lineages1[11:15] <- 9:5
   lineages2[133:154] <- 133:112
 
@@ -92,13 +92,13 @@ test_that("nltt_diff_exact_extinct: use normalize", {
   event_times2 <- sort(runif(154, 0, 10))
 
   # Test of non-increasing lineages
-  lineages1 <- seq_along(event_times)
-  lineages2 <- seq_along(event_times2)
+  lineages1 <- 1:length(event_times)
+  lineages2 <- 1:length(event_times2)
   lineages1[11:15] <- 9:5
   lineages2[133:154] <- 133:112
 
   stored <- 0.21989107217693629
-  testthat::expect_equal(
+  expect_equal(
     measured <- nLTT::nltt_diff_exact_extinct(
       event_times = event_times,
       species_number  = lineages1,

--- a/tests/testthat/test-nltt_diff_exact_extinct.R
+++ b/tests/testthat/test-nltt_diff_exact_extinct.R
@@ -26,8 +26,8 @@ test_that("nltt_diff_exact_extinct: use don't normalize", {
   event_times2 <- sort(runif(154, 0, 10))
 
   # Test of non-increasing lineages
-  lineages1 <- 1:length(event_times)
-  lineages2 <- 1:length(event_times2)
+  lineages1 <- seq_along(event_times)
+  lineages2 <- seq_along(event_times2)
   lineages1[11:15] <- 9:5
   lineages2[133:154] <- 133:112
 
@@ -92,8 +92,8 @@ test_that("nltt_diff_exact_extinct: use normalize", {
   event_times2 <- sort(runif(154, 0, 10))
 
   # Test of non-increasing lineages
-  lineages1 <- 1:length(event_times)
-  lineages2 <- 1:length(event_times2)
+  lineages1 <- seq_along(event_times)
+  lineages2 <- seq_along(event_times2)
   lineages1[11:15] <- 9:5
   lineages2[133:154] <- 133:112
 


### PR DESCRIPTION
As described in #52, @lintr-bot gives warnings regarding cyclomatic complexity.
I have reduced it in `nltt_diff_exact_extinct()` by splitting the input checking onto a dedicated, internal function: `check_input_event_times()`. In the processes I also (hopefully) simplified and made a few checks slightly more legible.
As far as I can see all tests and checks pass, so this should contribute to fixing #52!

@thijsjanzen, @richelbilderbeek, please let me know if I can help further, of if I should make some modifications on my additions 👍 